### PR TITLE
Support custom prompts from repo and home directories

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1845,12 +1845,12 @@ mod handlers {
     }
 
     pub async fn list_custom_prompts(sess: &Session, sub_id: String) {
-        let custom_prompts: Vec<CustomPrompt> =
-            if let Some(dir) = crate::custom_prompts::default_prompts_dir() {
-                crate::custom_prompts::discover_prompts_in(&dir).await
-            } else {
-                Vec::new()
-            };
+        let cwd = {
+            let state = sess.state.lock().await;
+            state.session_configuration.cwd.clone()
+        };
+
+        let custom_prompts: Vec<CustomPrompt> = crate::custom_prompts::discover_prompts(&cwd).await;
 
         let event = Event {
             id: sub_id,

--- a/docs/logs/001_prompt_search.md
+++ b/docs/logs/001_prompt_search.md
@@ -1,0 +1,8 @@
+# 001 prompt_search
+
+- [x] リポジトリの基本情報とドキュメント確認（AGENTS.md、README系、README.dev.mdの有無確認。README.dev.md は未確認=未存在）
+- [x] プロンプト探索ルート統合関数の設計と実装（ホームとリポジトリを統合し優先順位を設定）
+- [x] 既存呼び出しの置き換えと重複処理の実装（list_custom_prompts を新関数経由に変更）
+- [x] TUI/CLI への反映確認と必要な修正（ListCustomPrompts イベント経由で拡張リストを供給）
+- [x] テスト追加・実行と結果確認（custom_prompts モジュールの統合テスト追加、`cargo test -p codex-core custom_prompts` 実行）
+- [x] 変更内容の最終確認と後処理（フォーマット実行、lint 修正、テスト、コミット、PR 作成準備）


### PR DESCRIPTION
## Summary
- add multi-root prompt discovery that combines repository `.codex/prompts` and the user prompt directory, prioritizing repo-specific prompts when names conflict
- switch custom prompt listing to use the merged set and keep results deterministically sorted
- cover home/repo and duplicate prompt cases with new unit tests

## Testing
- cargo fmt -- --config imports_granularity=Item
- cargo test -p codex-core custom_prompts
- just fix -p codex-core


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b9853cf18832ea9c9e4e08e53d6fb)