### PR TITLE
docs: codex-mine (local build) notes + installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,7 @@ If you don’t have the tool:
   let request = mock.single_request();
   // assert using request.function_call_output(call_id) or request.json_body() or other helpers.
   ```
+
+# Headings
+
+- `codex-mine` の説明、および `codex-mine` 向けの機能・運用ルールは `README_mine.md` に追記していくこと（一般向けドキュメントや共通仕様に混ぜない）。

--- a/README_mine.md
+++ b/README_mine.md
@@ -1,0 +1,22 @@
+# codex-mine
+
+このリポジトリをローカルでビルドした Rust 版 Codex を、npm で入れている `codex` と衝突させずに並行運用するためのメモ。
+
+## インストール/更新
+
+リポジトリ直下で実行:
+
+- `./scripts/install-codex-mine.sh`
+
+## 起動コマンド
+
+- npm 版: `codex`
+- ローカルビルド版: `codex-mine`
+  - 実体は `~/.local/codex-mine/bin/codex`
+  - `~/.local/bin/codex-mine` はラッパーで、起動時に `--config check_for_update_on_startup=false` を付けて「Update available!」の通知を無効化する
+
+## 追加機能
+本家との差分機能のリスト。
+
+- **カスタムプロンプト探索ルートの拡張**: 「リポジトリ内 `.codex/prompts`」と「`$CODEX_HOME/prompts`」を探索し、同名はリポジトリ側が優先
+

--- a/scripts/install-codex-mine.sh
+++ b/scripts/install-codex-mine.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+slug="mine"
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+codex_rs_cli_dir="$repo_root/codex-rs/cli"
+
+install_root="${CODEX_MINE_ROOT:-$HOME/.local/codex-$slug}"
+bin_dir="${CODEX_MINE_BIN_DIR:-$HOME/.local/bin}"
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'ERROR: required command not found: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+need_cmd cargo
+
+if [ ! -d "$codex_rs_cli_dir" ]; then
+  printf 'ERROR: expected directory not found: %s\n' "$codex_rs_cli_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$bin_dir"
+
+printf '==> Installing Rust Codex CLI to %s\n' "$install_root" >&2
+cargo install --path "$codex_rs_cli_dir" --bin codex --root "$install_root" --force
+
+printf '==> Writing wrapper: %s\n' "$bin_dir/codex-$slug" >&2
+cat > "$bin_dir/codex-$slug" <<SH
+#!/bin/sh
+set -eu
+exec "$install_root/bin/codex" --config check_for_update_on_startup=false "\$@"
+SH
+chmod +x "$bin_dir/codex-$slug"
+
+printf '\nOK: %s\n' "$bin_dir/codex-$slug" >&2
+printf 'NOTE: %s must be on your PATH\n' "$bin_dir" >&2
+printf 'Try: %s\n' "codex-$slug --version" >&2


### PR DESCRIPTION
codex-mine 用のドキュメントとインストールスクリプトを追加。

- AGENTS.md: mine向けの記述は README_mine.md に集約
- README_mine.md: codex-mine の運用メモ（追加機能リスト）
- scripts/install-codex-mine.sh: ビルド/再インストール + ラッパー生成

NOTE: .codex/ はローカル用としてPRに含めていません。