### PR TITLE
chore: ignore local .memo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ CHANGELOG.ignore.md
 # nix related
 .direnv
 .envrc
+
+# local memos
+.memo/


### PR DESCRIPTION
## Summary
- Ignore `.memo/` so local handover notes and scratch logs don’t get committed

## Notes
- Moved local `docs/logs/004_subagents_plan.md` into `.memo/logs/` (not part of git).
