### PR TITLE
cli: propagate -C/--cd to mcp

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -473,6 +473,9 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
             codex_mcp_server::run_main(codex_linux_sandbox_exe, root_config_overrides).await?;
         }
         Some(Subcommand::Mcp(mut mcp_cli)) => {
+            // Propagate the top-level working directory flag so repository-local configuration
+            // resolution stays consistent across subcommands.
+            mcp_cli.cwd = interactive.cwd.clone();
             // Propagate any root-level config overrides (e.g. `-c key=value`).
             prepend_config_flags(&mut mcp_cli.config_overrides, root_config_overrides.clone());
             mcp_cli.run().await?;


### PR DESCRIPTION
## Summary
- Propagate top-level `-C/--cd` to `codex mcp ...` so cwd-dependent configuration resolves consistently.

## Testing
- `just fmt`
- `just fix -p codex-cli`
- `cargo test -p codex-cli`
