### PR TITLE
CI fix: unblock PR#12

### DIFF
--- a/codex-rs/core/src/rollout/policy.rs
+++ b/codex-rs/core/src/rollout/policy.rs
@@ -41,6 +41,8 @@ pub(crate) fn should_persist_event_msg(ev: &EventMsg) -> bool {
         | EventMsg::AgentMessage(_)
         | EventMsg::AgentReasoning(_)
         | EventMsg::AgentReasoningRawContent(_)
+        | EventMsg::SubAgentRunBegin(_)
+        | EventMsg::SubAgentRunEnd(_)
         | EventMsg::TokenCount(_)
         | EventMsg::ContextCompacted(_)
         | EventMsg::EnteredReviewMode(_)
@@ -59,8 +61,6 @@ pub(crate) fn should_persist_event_msg(ev: &EventMsg) -> bool {
         | EventMsg::SessionConfigured(_)
         | EventMsg::McpToolCallBegin(_)
         | EventMsg::McpToolCallEnd(_)
-        | EventMsg::SubAgentRunBegin(_)
-        | EventMsg::SubAgentRunEnd(_)
         | EventMsg::WebSearchBegin(_)
         | EventMsg::WebSearchEnd(_)
         | EventMsg::ExecCommandBegin(_)
@@ -90,5 +90,32 @@ pub(crate) fn should_persist_event_msg(ev: &EventMsg) -> bool {
         | EventMsg::AgentMessageContentDelta(_)
         | EventMsg::ReasoningContentDelta(_)
         | EventMsg::ReasoningRawContentDelta(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::SubAgentRunBeginEvent;
+    use crate::protocol::SubAgentRunEndEvent;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn subagent_run_events_are_persisted() {
+        let begin = EventMsg::SubAgentRunBegin(SubAgentRunBeginEvent {
+            call_id: "call-1".to_string(),
+            name: "helper".to_string(),
+            description: "desc".to_string(),
+            color: None,
+            prompt: "do the thing".to_string(),
+        });
+        assert_eq!(should_persist_event_msg(&begin), true);
+
+        let end = EventMsg::SubAgentRunEnd(SubAgentRunEndEvent {
+            call_id: "call-1".to_string(),
+            duration_ms: 123,
+            success: true,
+        });
+        assert_eq!(should_persist_event_msg(&end), true);
     }
 }


### PR DESCRIPTION
PR#12 のCI失敗を解消する修正です。\n\n- rust-ci(Lint/Build): codex-tui2 の unused メソッドを削除\n- rust-ci(Tests windows): app-server の flaky テストを安定化(wiremock期待/承認フロー)\n- ci/build-test: stage_npm_packages.py が openai/codex を参照するよう修正\n\nローカル検証:\n- just fix -p codex-tui2 / codex-app-server\n- cargo test -p codex-tui2\n- cargo test -p codex-app-server --test all suite::codex_message_processor_flow